### PR TITLE
Remove unused stream name attribute for channels from SDK.

### DIFF
--- a/src/net/Client/Live/AudioStream.cs
+++ b/src/net/Client/Live/AudioStream.cs
@@ -25,11 +25,6 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
         public int Index { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of audio stream.
-        /// </summary>
-        public string Name {get;  set; } 
-
-        /// <summary>
         /// Gets or sets the language in the ISO 639-2 format for the source audio stream.
         /// </summary>
         public string Language { get; set; }

--- a/src/net/Client/Live/VideoStream.cs
+++ b/src/net/Client/Live/VideoStream.cs
@@ -23,10 +23,5 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
         /// Gets or sets the stream index when source from MPEG2-TS.
         /// </summary>
         public int Index { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name of video stream.
-        /// </summary>
-        public string Name { get; set; }
     }
 }

--- a/test/net/Scenario/Live/LiveTranscodingTest.cs
+++ b/test/net/Scenario/Live/LiveTranscodingTest.cs
@@ -16,9 +16,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Collections.ObjectModel;
 using System.Net;
-using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.MediaServices.Client.Tests.Common;
 
@@ -64,6 +63,50 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Live.Tests
 
             channel.Stop();
             channel.Delete();
+        }
+
+
+        [TestMethod]
+        [Priority(1)]
+        [TestCategory("ClientSDK")]
+        [Owner("ClientSDK")]
+        public void TestStreamSelectionPersistence()
+        {
+            var channelOptions = new ChannelCreationOptions
+            {
+                Name = Guid.NewGuid().ToString().Substring(0, 30),
+                Input = MakeChannelInput(),
+                Preview = MakeChannelPreview(),
+                Output = MakeChannelOutput(),
+                EncodingType = ChannelEncodingType.Standard,
+                Encoding = new ChannelEncoding
+                {
+                    SystemPreset = "Default720p",
+                    VideoStreams = new List<VideoStream>
+                    {
+                        new VideoStream { Index = 0 }
+                    }.AsReadOnly(),
+                    AudioStreams = new List<AudioStream>
+                    {
+                        new AudioStream { Index = 1, Language = "eng" },
+                        new AudioStream { Index = 2, Language = "fra" },
+                        new AudioStream { Index = 3, Language = "esp" }
+                    }.AsReadOnly(),
+                },
+            };
+
+            IChannel channel = _mediaContext.Channels.Create(channelOptions);
+            Assert.AreEqual(channelOptions.Encoding.AudioStreams.Count, channel.Encoding.AudioStreams.Count);
+            for (int i = 0; i < channelOptions.Encoding.AudioStreams.Count; ++i)
+            {
+                Assert.AreEqual(channelOptions.Encoding.AudioStreams[i].Index, channel.Encoding.AudioStreams[i].Index);
+                Assert.AreEqual(channelOptions.Encoding.AudioStreams[i].Language, channel.Encoding.AudioStreams[i].Language);
+            }
+            Assert.AreEqual(channelOptions.Encoding.VideoStreams.Count, channel.Encoding.VideoStreams.Count);
+            for (int i = 0; i < channelOptions.Encoding.VideoStreams.Count; ++i)
+            {
+                Assert.AreEqual(channelOptions.Encoding.VideoStreams[i].Index, channel.Encoding.VideoStreams[i].Index);
+            }
         }
 
         static ChannelInput MakeChannelInput()

--- a/test/net/unit/ChannelDataTest.cs
+++ b/test/net/unit/ChannelDataTest.cs
@@ -59,7 +59,6 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Live.UnitTests
             Assert.AreEqual(encoding.AudioStreams[0].Index, target.Encoding.AudioStreams[0].Index);
             Assert.AreEqual(encoding.AudioStreams[0].Language, target.Encoding.AudioStreams[0].Language);
             Assert.AreEqual(encoding.VideoStreams[0].Index, target.Encoding.VideoStreams[0].Index);
-            Assert.AreEqual(encoding.VideoStreams[0].Name, target.Encoding.VideoStreams[0].Name);
             Assert.AreEqual(encoding.IgnoreCea708ClosedCaptions, target.Encoding.IgnoreCea708ClosedCaptions);
             Assert.AreEqual(encoding.AdMarkerSource, target.Encoding.AdMarkerSource);
 
@@ -162,7 +161,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Live.UnitTests
             {
                 SystemPreset = "Default720p",
                 AudioStreams = new List<AudioStream> { new AudioStream { Index = 103, Language = "zhn" } }.AsReadOnly(),
-                VideoStreams = new List<VideoStream> { new VideoStream { Index = 104, Name = "English"} }.AsReadOnly(),
+                VideoStreams = new List<VideoStream> { new VideoStream { Index = 104 } }.AsReadOnly(),
                 IgnoreCea708ClosedCaptions = true,
                 AdMarkerSource = AdMarkerSource.Api
             };


### PR DESCRIPTION
Remove the Name attribute from AudioStream and VideoStream.