### PR TITLE
Performance improvements for smallfile upload/downloads

### DIFF
--- a/src/net/Client/Common/Common.BlobTransfer/BlobDownloader.cs
+++ b/src/net/Client/Common/Common.BlobTransfer/BlobDownloader.cs
@@ -87,6 +87,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
             CloudBlockBlob blob = null;
             BlobTransferContext transferContext = new BlobTransferContext();
             transferContext.Exceptions = new ConcurrentBag<Exception>();
+
             try
             {
                 blob = GetCloudBlockBlob(uri, client, retryPolicy, getSharedAccessSignature);
@@ -123,6 +124,13 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                     {
                     }
 
+                }
+                else if (sizeToDownload < cloudBlockBlobUploadDownloadSizeLimit)
+                {
+                    AccessCondition accessCondition = AccessCondition.GenerateEmptyCondition();
+                    OperationContext operationContext = new OperationContext();
+                    operationContext.ClientRequestID = DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture);
+                    blob.DownloadToFile(localFile, FileMode.OpenOrCreate, accessCondition : accessCondition , options: blobRequestOptions , operationContext : operationContext);
                 }
                 else
                 {

--- a/src/net/Client/Common/Common.BlobTransfer/BlobDownloader.cs
+++ b/src/net/Client/Common/Common.BlobTransfer/BlobDownloader.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Security.Cryptography;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -49,14 +50,14 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
             long start = 0,
             long length = -1,
             int parallelTransferThreadCount = 10,
-            int numberOfConcurrentTransfers = 2)
+            int numberOfConcurrentTransfers = default(int))
         {
             if (client != null && getSharedAccessSignature != null)
             {
                 throw new InvalidOperationException("The arguments client and getSharedAccessSignature cannot both be non-null");
             }
 
-            SetConnectionLimits(uri, Environment.ProcessorCount * numberOfConcurrentTransfers * parallelTransferThreadCount);
+            SetConnectionLimits(uri, numberOfConcurrentTransfers);
 
             Task task =
                 Task.Factory.StartNew(
@@ -81,7 +82,6 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
             long length = -1,
             int parallelTransferThreadCount = 10)
         {
-            int numThreads = Environment.ProcessorCount * parallelTransferThreadCount;
             ManualResetEvent downloadCompletedSignal = new ManualResetEvent(false);
             BlobRequestOptions blobRequestOptions = new BlobRequestOptions { RetryPolicy = retryPolicy };
             CloudBlockBlob blob = null;
@@ -112,6 +112,14 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
 
                     sizeToDownload = length;
                 }
+                transferContext.Length = sizeToDownload;
+                transferContext.LocalFilePath = localFile;
+                transferContext.OnComplete = () => downloadCompletedSignal.Set();
+                transferContext.Blob = blob;
+                transferContext.FileEncryption = fileEncryption;
+                transferContext.InitializationVector = initializationVector;
+                transferContext.InitialOffset = start;
+
                 if (sizeToDownload == 0)
                 {
                     using (FileStream stream =
@@ -130,10 +138,40 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                     AccessCondition accessCondition = AccessCondition.GenerateEmptyCondition();
                     OperationContext operationContext = new OperationContext();
                     operationContext.ClientRequestID = DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture);
-                    blob.DownloadToFile(localFile, FileMode.OpenOrCreate, accessCondition : accessCondition , options: blobRequestOptions , operationContext : operationContext);
+                    using (FileStream fileStream = new FileStream(
+                        transferContext.LocalFilePath,
+                        FileMode.OpenOrCreate,
+                        FileAccess.ReadWrite,
+                        FileShare.Read
+                        ))
+                    {
+                        blob.DownloadToStream(fileStream, accessCondition: accessCondition, options: blobRequestOptions, operationContext: operationContext);
+                        if (fileEncryption != null)
+                        {
+                            using (MemoryStream msDecrypt = new MemoryStream())
+                            {
+                                //Using CryptoTransform APIs per Quintin's suggestion.
+                                using (FileEncryptionTransform fileEncryptionTransform = fileEncryption.GetTransform(initializationVector, 0))
+                                {
+                                    fileStream.Position = 0;
+                                    fileStream.CopyTo(msDecrypt);
+                                    msDecrypt.Position = 0;
+                                    fileStream.Position = 0;
+                                    using (CryptoStream csEncrypt = new CryptoStream(msDecrypt, fileEncryptionTransform, CryptoStreamMode.Read))
+                                    {
+                                        csEncrypt.CopyTo(fileStream);                                   
+                                    }
+                                }
+                            }
+                            
+                        }
+                   }
+                    InvokeProgressCallback(transferContext, sizeToDownload, sizeToDownload);
+                    transferContext.OnComplete();
                 }
                 else
                 {
+                    int numThreads = parallelTransferThreadCount;
                     int blockSize = GetBlockSize(blob.Properties.Length);
 
                     transferContext.BlocksToTransfer = PrepareUploadDownloadQueue(sizeToDownload, blockSize,
@@ -146,12 +184,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                     }
                     transferContext.BlockSize = blockSize;
                     transferContext.CancellationToken = cancellationToken;
-                    transferContext.Blob = blob;
                     transferContext.BlobRequestOptions = blobRequestOptions;
-                    transferContext.Length = sizeToDownload;
-
-                    transferContext.LocalFilePath = localFile;
-                    transferContext.OnComplete = () => downloadCompletedSignal.Set();
                     transferContext.MemoryManager = MemoryManagerFactory.GetMemoryManager(blockSize);
                     transferContext.Client = client;
                     transferContext.RetryPolicy = retryPolicy;
@@ -159,9 +192,6 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                     transferContext.ShouldDoFileIO = shouldDoFileIO;
                     transferContext.BufferStreams = new ConcurrentDictionary<byte[], MemoryStream>();
                     transferContext.ClientRequestId = DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture);
-                    transferContext.FileEncryption = fileEncryption;
-                    transferContext.InitializationVector = initializationVector;
-                    transferContext.InitialOffset = start;
 
                     using (FileStream stream = new FileStream(
                         transferContext.LocalFilePath,

--- a/src/net/Client/Common/Common.BlobTransfer/BlobTransferBase.cs
+++ b/src/net/Client/Common/Common.BlobTransfer/BlobTransferBase.cs
@@ -35,7 +35,6 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
         private readonly BlobTransferSpeedCalculator _uploadDownloadSpeedCalculator = 
             new BlobTransferSpeedCalculator(SpeedCalculatorCapacity);
         protected readonly long cloudBlockBlobUploadDownloadSizeLimit = 32 * 1024 * 1024;
-
         public event EventHandler<BlobTransferCompleteEventArgs> TransferCompleted;
 
         public event EventHandler<BlobTransferProgressChangedEventArgs> TransferProgressChanged;

--- a/src/net/Client/Common/Common.BlobTransfer/BlobTransferBase.cs
+++ b/src/net/Client/Common/Common.BlobTransfer/BlobTransferBase.cs
@@ -34,6 +34,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
         private readonly TimeSpan SasPolicyActivationMaxTimeThreshold = TimeSpan.FromSeconds(5);
         private readonly BlobTransferSpeedCalculator _uploadDownloadSpeedCalculator = 
             new BlobTransferSpeedCalculator(SpeedCalculatorCapacity);
+        protected readonly long cloudBlockBlobUploadDownloadSizeLimit = 32 * 1024 * 1024;
 
         public event EventHandler<BlobTransferCompleteEventArgs> TransferCompleted;
 

--- a/src/net/Client/Common/Common.BlobTransfer/BlobTransferClient.cs
+++ b/src/net/Client/Common/Common.BlobTransfer/BlobTransferClient.cs
@@ -65,8 +65,8 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
 		public BlobTransferClient(TimeSpan forceSharedAccessSignatureRetry = default(TimeSpan))
 		{
 			_forceSharedAccessSignatureRetry = forceSharedAccessSignatureRetry;
-			ParallelTransferThreadCount = 10;
-			NumberOfConcurrentTransfers = 2;
+            ParallelTransferThreadCount = ServicePointModifier.DefaultConnectionLimit();
+            NumberOfConcurrentTransfers = ServicePointModifier.DefaultConnectionLimit();
 		}
 
 		/// <summary>

--- a/src/net/Client/Common/Common.BlobTransfer/BlobUploader.cs
+++ b/src/net/Client/Common/Common.BlobTransfer/BlobUploader.cs
@@ -107,6 +107,13 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                 {
                     blob.UploadFromByteArray(new byte[1], 0, 0, options: blobRequestOptions);
                 }
+                else if (fileSize < cloudBlockBlobUploadDownloadSizeLimit)
+                {
+                    AccessCondition accessCondition = AccessCondition.GenerateEmptyCondition();
+                    OperationContext operationContext = new OperationContext();
+                    operationContext.ClientRequestID = DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture);
+                    blob.UploadFromFile(localFile, FileMode.Open, accessCondition: accessCondition, options: blobRequestOptions, operationContext: operationContext);
+                }
                 else
                 {
                     int numThreads = Environment.ProcessorCount * parallelTransferThreadCount;

--- a/src/net/Client/Common/Common.BlobTransfer/BlobUploader.cs
+++ b/src/net/Client/Common/Common.BlobTransfer/BlobUploader.cs
@@ -21,6 +21,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -49,9 +50,9 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
             string subDirectory = "",
             Func<string> getSharedAccessSignature = null,
             int parallelTransferThreadCount = 10,
-            int numberOfConcurrentTransfers = 2)
+            int numberOfConcurrentTransfers = default(int))
         {
-            SetConnectionLimits(url, Environment.ProcessorCount * parallelTransferThreadCount * numberOfConcurrentTransfers);
+            SetConnectionLimits(url, numberOfConcurrentTransfers);
             return Task.Factory.StartNew(
                 () => UploadFileToBlob(
                     cancellationToken,
@@ -84,74 +85,90 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
             transferContext.Exceptions = new ConcurrentBag<Exception>();
             try
             {
-                //attempt to open the file first so that we throw an exception before getting into the async work
-                using (new FileStream(localFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                {
-                }
-
-                ManualResetEvent uploadCompletedSignal = new ManualResetEvent(false);
-                BlobRequestOptions blobRequestOptions = new BlobRequestOptions
-                {
-                    RetryPolicy = retryPolicy,
-                    ServerTimeout = TimeSpan.FromSeconds(90)
-                };
-
-                CloudBlockBlob blob = GetCloudBlockBlob(uri, client, subDirectory, localFile, contentType,
-                    getSharedAccessSignature);
-                BlobPolicyActivationWait(() => blob.DeleteIfExists(options: blobRequestOptions));
-
-                FileInfo file = new FileInfo(localFile);
-                long fileSize = file.Length;
-
-                if (fileSize == 0)
-                {
-                    blob.UploadFromByteArray(new byte[1], 0, 0, options: blobRequestOptions);
-                }
-                else if (fileSize < cloudBlockBlobUploadDownloadSizeLimit)
-                {
-                    AccessCondition accessCondition = AccessCondition.GenerateEmptyCondition();
-                    OperationContext operationContext = new OperationContext();
-                    operationContext.ClientRequestID = DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture);
-                    blob.UploadFromFile(localFile, FileMode.Open, accessCondition: accessCondition, options: blobRequestOptions, operationContext: operationContext);
-                }
-                else
-                {
-                    int numThreads = Environment.ProcessorCount * parallelTransferThreadCount;
-                    int blockSize = GetBlockSize(fileSize);
-
-                    transferContext.BlocksToTransfer = PrepareUploadDownloadQueue(fileSize, blockSize, ref numThreads);
-
-                    transferContext.BlocksForFileIO = new ConcurrentDictionary<int, byte[]>();
-                    for (int i = 0; i < transferContext.BlocksToTransfer.Count(); i++)
+                    ManualResetEvent uploadCompletedSignal = new ManualResetEvent(false);
+                    BlobRequestOptions blobRequestOptions = new BlobRequestOptions
                     {
-                        transferContext.BlocksForFileIO[i] = null;
+                        RetryPolicy = retryPolicy,
+                        ServerTimeout = TimeSpan.FromSeconds(90)
+                    };
+                    //attempt to open the file first so that we throw an exception before getting into the async work
+                    using (FileStream fileStream = new FileStream(localFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    {
                     }
-                    transferContext.BlockSize = blockSize;
-                    transferContext.CancellationToken = cancellationToken;
-                    transferContext.Blob = blob;
-                    transferContext.BlobRequestOptions = blobRequestOptions;
+                    CloudBlockBlob blob = GetCloudBlockBlob(uri, client, subDirectory, localFile, contentType,
+                        getSharedAccessSignature);
+                    BlobPolicyActivationWait(() => blob.DeleteIfExists(options: blobRequestOptions));
+
+                    FileInfo file = new FileInfo(localFile);
+                    long fileSize = file.Length;
                     transferContext.Length = fileSize;
                     transferContext.LocalFilePath = localFile;
                     transferContext.OnComplete = () => uploadCompletedSignal.Set();
-                    transferContext.MemoryManager = MemoryManagerFactory.GetMemoryManager(blockSize);
-                    transferContext.Client = client;
-                    transferContext.RetryPolicy = retryPolicy;
-                    transferContext.GetSharedAccessSignature = getSharedAccessSignature;
-                    transferContext.ShouldDoFileIO = shouldDoFileIO;
-                    transferContext.BufferStreams = new ConcurrentDictionary<byte[], MemoryStream>();
-                    transferContext.ClientRequestId = DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture);
+                    transferContext.Blob = blob;
                     transferContext.FileEncryption = fileEncryption;
-                    transferContext.ContentType = contentType;
-                    transferContext.BlobSubFolder = subDirectory;
-                    transferContext.NextFileIOBlock = 0;
-                    transferContext.PartialFileIOState = new ConcurrentDictionary<long, int>();
-
-                    using (
-                        FileStream stream = new FileStream(localFile, FileMode.Open, FileAccess.Read,
-                            FileShare.ReadWrite))
+                    if (fileSize == 0)
                     {
-                        RunUploadLoop(transferContext, stream, numThreads);
+                        blob.UploadFromByteArray(new byte[1], 0, 0, options: blobRequestOptions);
                     }
+                    else if (fileSize < cloudBlockBlobUploadDownloadSizeLimit)
+                    {
+                        AccessCondition accessCondition = AccessCondition.GenerateEmptyCondition();
+                        OperationContext operationContext = new OperationContext();
+                        operationContext.ClientRequestID = DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture);
+                        using (FileStream fileStream = new FileStream(localFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                        {
+                               using (var memoryStream = new MemoryStream())
+                                     {
+                                         fileStream.CopyTo(memoryStream);
+                                         byte[] fileContent = memoryStream.ToArray();
+                                         ApplyEncryptionTransform(
+                                                     transferContext.FileEncryption,
+                                                     Path.GetFileName(transferContext.LocalFilePath),
+                                                     0,
+                                                     fileContent,
+                                                     Convert.ToInt32(fileStream.Length));
+                                         using (var uploadMemoryStream = new MemoryStream(fileContent))
+                                         {
+                                             blob.UploadFromStream(uploadMemoryStream, accessCondition: accessCondition, options: blobRequestOptions, operationContext: operationContext);
+                                         }
+                                     }                            
+                        }
+                        InvokeProgressCallback(transferContext, fileSize, fileSize);
+                        transferContext.OnComplete();
+                    }
+                    else
+                    {
+                        int numThreads = parallelTransferThreadCount;
+                        int blockSize = GetBlockSize(fileSize);
+
+                        transferContext.BlocksToTransfer = PrepareUploadDownloadQueue(fileSize, blockSize, ref numThreads);
+
+                        transferContext.BlocksForFileIO = new ConcurrentDictionary<int, byte[]>();
+                        for (int i = 0; i < transferContext.BlocksToTransfer.Count(); i++)
+                        {
+                            transferContext.BlocksForFileIO[i] = null;
+                        }
+                        transferContext.BlockSize = blockSize;
+                        transferContext.CancellationToken = cancellationToken;
+                        transferContext.BlobRequestOptions = blobRequestOptions;
+                        transferContext.MemoryManager = MemoryManagerFactory.GetMemoryManager(blockSize);
+                        transferContext.Client = client;
+                        transferContext.RetryPolicy = retryPolicy;
+                        transferContext.GetSharedAccessSignature = getSharedAccessSignature;
+                        transferContext.ShouldDoFileIO = shouldDoFileIO;
+                        transferContext.BufferStreams = new ConcurrentDictionary<byte[], MemoryStream>();
+                        transferContext.ClientRequestId = DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture);
+                        transferContext.ContentType = contentType;
+                        transferContext.BlobSubFolder = subDirectory;
+                        transferContext.NextFileIOBlock = 0;
+                        transferContext.PartialFileIOState = new ConcurrentDictionary<long, int>();
+
+                        using (
+                            FileStream stream = new FileStream(localFile, FileMode.Open, FileAccess.Read,
+                                FileShare.ReadWrite))
+                        {
+                            RunUploadLoop(transferContext, stream, numThreads);
+                        }
                 }
             }
             catch (Exception e)

--- a/src/net/Client/Common/Common.BlobTransfer/MemoryManager.cs
+++ b/src/net/Client/Common/Common.BlobTransfer/MemoryManager.cs
@@ -26,7 +26,12 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
 
         private int _buffersInUse;
 
-        public MemoryManager(int bufferSize, long capacity = 0x4000000L)
+        public MemoryManager(int bufferSize)
+            : this(bufferSize, Environment.Is64BitProcess ? 0x40000000L : 0x4000000L)
+        {
+        }
+
+        public MemoryManager(int bufferSize, long capacity)
         {
             long num = capacity / ((long)bufferSize);
             int cellsCount = (int)Math.Min(0x2000L, num);

--- a/src/net/Client/Common/Common.BlobTransfer/ServicePointModifier.cs
+++ b/src/net/Client/Common/Common.BlobTransfer/ServicePointModifier.cs
@@ -22,7 +22,13 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
     internal static class ServicePointModifier
     {
         private const int DefaultConnectionLimitMultiplier = 8;
+        private const int MaxConnectionLimit = 30;
         private static readonly TimeSpan DefaultConnectionLeaseTimeout = TimeSpan.FromMinutes(5);
+
+ 	    public static int DefaultConnectionLimit()
+        {
+            return Math.Min(MaxConnectionLimit, Environment.ProcessorCount * DefaultConnectionLimitMultiplier);
+        }
 
         public static void SetConnectionPropertiesForSmallPayloads(
             Uri uri,

--- a/test/net/Scenario/AssetFilesTests.cs
+++ b/test/net/Scenario/AssetFilesTests.cs
@@ -245,7 +245,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Tests
         }
 
         [TestMethod]
-        [Timeout(60000)]
+        [Timeout(600000)]
         [DeploymentItem(@"Media\SmallWmv.wmv", "Media")]
         public void ShouldDownloadManyConcurrentSmallFiles()
         {
@@ -256,8 +256,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Tests
 
             Assert.AreEqual(assetFile.Asset.Id, asset.Id);
             Assert.AreEqual(1, asset.Locators.Count);
-            VerifyAndDownloadAssetFileNTimes(assetFile, asset,10,0,true);
-
+            VerifyAndDownloadAssetFileNTimes(assetFile, asset,100,0,true);
         }
         [TestMethod]
         [Timeout(60000)]


### PR DESCRIPTION
Using blob storage upload/download api vs mediaservices upload/download api for small files.
Testing: Tried small files using blobstorage upload/download vs media services upload/download and saw upto 100% improvement in performance. 
Ivan did some analysis on this on what is a good cut off number to use one vs the other.
