### PR TITLE
Accept the identifier with uuid prefix for querying telemetry data in SDK

### DIFF
--- a/src/net/Client/Telemetry/ChannelMetricsCollection.cs
+++ b/src/net/Client/Telemetry/ChannelMetricsCollection.cs
@@ -99,11 +99,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                 throw new ArgumentException(StringTable.InvalidMediaServicesAccountIdInput);
             }
 
-            Guid channelGuid;
-            if (!Guid.TryParse(channelId, out channelGuid))
-            {
-                throw new ArgumentException(StringTable.InvalidChannelInput);
-            }
+            var channelGuid = TelemetryUtilities.ParseChannelId(channelId);
 
             if (start.Kind != DateTimeKind.Utc)
             {

--- a/src/net/Client/Telemetry/StreamingEndPointRequestLogCollection.cs
+++ b/src/net/Client/Telemetry/StreamingEndPointRequestLogCollection.cs
@@ -99,11 +99,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                 throw new ArgumentException(StringTable.InvalidMediaServicesAccountIdInput);
             }
 
-            Guid streamingEndPointGuid;
-            if (!Guid.TryParse(streamingEndPointId, out streamingEndPointGuid))
-            {
-                throw new ArgumentException(StringTable.InvalidStreamingEndPointInput);
-            }
+            var streamingEndPointGuid = TelemetryUtilities.ParseStreamingEndPointId(streamingEndPointId);
 
             if (start.Kind != DateTimeKind.Utc)
             {

--- a/src/net/Client/Telemetry/TelemetryUtilities.cs
+++ b/src/net/Client/Telemetry/TelemetryUtilities.cs
@@ -21,6 +21,16 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
     internal static class TelemetryUtilities
     {
         /// <summary>
+        /// The prefix for the streaming endpoint Id.
+        /// </summary>
+        private const string StreamingEndPointIdentifierPrefix = "nb:oid:UUID:";
+
+        /// <summary>
+        /// The prefix for the channel Id.
+        /// </summary>
+        private const string ChannelIdentifierPrefix = "nb:chid:UUID:";
+
+        /// <summary>
         /// Get storage account name from the given endpoint address
         /// </summary>
         /// <param name="endpointAddress"></param>
@@ -34,6 +44,56 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                 throw new UriFormatException("endpointAddress");
             }
             return entries[0];
+        }
+
+        /// <summary>
+        /// Validate and parse the streaming endpoint Id to Guid format.
+        /// </summary>
+        /// <param name="streamingEndpointId">The streaming endpoint Id.</param>
+        /// <returns>The Guid format of the streaming endpoint Id.</returns>
+        public static Guid ParseStreamingEndPointId(string streamingEndpointId)
+        {
+            if (String.IsNullOrWhiteSpace(streamingEndpointId))
+            {
+                throw new ArgumentException("streamingEndpointId");
+            }
+
+            if (streamingEndpointId.StartsWith(StreamingEndPointIdentifierPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                streamingEndpointId = streamingEndpointId.Remove(0, StreamingEndPointIdentifierPrefix.Length);
+            }
+
+            Guid streamingEndpointIdGuid;
+            if (!Guid.TryParse(streamingEndpointId, out streamingEndpointIdGuid))
+            {
+                throw new ArgumentException(StringTable.InvalidStreamingEndPointInput);
+            }
+            return streamingEndpointIdGuid;
+        }
+
+        /// <summary>
+        /// Validate and parse the channel Id to Guid format.
+        /// </summary>
+        /// <param name="channelId">The Channel Id.</param>
+        /// <returns>The Guid format of the streaming endpoint Id.</returns>
+        public static Guid ParseChannelId(string channelId)
+        {
+            if (String.IsNullOrWhiteSpace(channelId))
+            {
+                throw new ArgumentException("channelId.");
+            }
+
+            if (channelId.StartsWith(ChannelIdentifierPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                channelId = channelId.Remove(0, ChannelIdentifierPrefix.Length);
+            }
+
+            Guid channelIdGuid;
+            if (!Guid.TryParse(channelId, out channelIdGuid))
+            {
+                throw new ArgumentException(StringTable.InvalidChannelInput);
+            }
+            return channelIdGuid;
         }
     }
 }

--- a/test/net/Scenario/Telemetry/ChannelMetricsCollectionE2ETests.cs
+++ b/test/net/Scenario/Telemetry/ChannelMetricsCollectionE2ETests.cs
@@ -97,6 +97,8 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Tests
 
         private readonly TraceListener _consoleTraceListener = new ConsoleTraceListener();
 
+        private const string ChannelIdentifierPrefix = "nb:chid:UUID:";
+
         [TestInitialize]
         public void SetupTest()
         {
@@ -159,36 +161,42 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Tests
 
         private void TestQuery1()
         {
-            var res = _mediaConext.ChannelMetrics.GetChannelMetrics(
-                GetTableEndPoint(),
-                WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountKey,
-                AccountId.ToString(),
-                ChannelId.ToString(),
-                new DateTime(2011, 3, 2, 21, 53, 38, DateTimeKind.Utc),
-                new DateTime(2011, 3, 2, 21, 53, 40, DateTimeKind.Utc));
-            Assert.IsNotNull(res);
-            var resArray = res.ToArray();
-            Assert.AreEqual(resArray.Length, 2);
-            VerifyResult(resArray[0], TestData[0]);
-            VerifyResult(resArray[1], TestData[1]);
+            GetChannelIds().ForEach(channelId =>
+            {
+                var res = _mediaConext.ChannelMetrics.GetChannelMetrics(
+                    GetTableEndPoint(),
+                    WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountKey,
+                    AccountId.ToString(),
+                    channelId,
+                    new DateTime(2011, 3, 2, 21, 53, 38, DateTimeKind.Utc),
+                    new DateTime(2011, 3, 2, 21, 53, 40, DateTimeKind.Utc));
+                Assert.IsNotNull(res);
+                var resArray = res.ToArray();
+                Assert.AreEqual(resArray.Length, 2);
+                VerifyResult(resArray[0], TestData[0]);
+                VerifyResult(resArray[1], TestData[1]);                  
+            });
         }
 
         private void TestQuery2()
         {
-            ICollection<IChannelHeartbeat> res = _mediaConext.ChannelMetrics.GetChannelMetrics(
-                GetTableEndPoint(),
-                WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountKey,
-                AccountId.ToString(),
-                ChannelId.ToString(),
-                new DateTime(2011, 3, 2, 21, 53, 38, DateTimeKind.Utc),
-                new DateTime(2011, 3, 3, 21, 53, 40, DateTimeKind.Utc));
-            Assert.IsNotNull(res);
-            IChannelHeartbeat[] resArray = res.ToArray();
-            Assert.AreEqual(resArray.Length, 4);
-            VerifyResult(resArray[0], TestData[0]);
-            VerifyResult(resArray[1], TestData[1]);
-            VerifyResult(resArray[2], TestData[2]);
-            VerifyResult(resArray[3], TestData[3]);
+            GetChannelIds().ForEach(channelId =>
+            {
+                var res = _mediaConext.ChannelMetrics.GetChannelMetrics(
+                    GetTableEndPoint(),
+                    WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountKey,
+                    AccountId.ToString(),
+                    channelId,
+                    new DateTime(2011, 3, 2, 21, 53, 38, DateTimeKind.Utc),
+                    new DateTime(2011, 3, 3, 21, 53, 40, DateTimeKind.Utc));
+                Assert.IsNotNull(res);
+                var resArray = res.ToArray();
+                Assert.AreEqual(resArray.Length, 4);
+                VerifyResult(resArray[0], TestData[0]);
+                VerifyResult(resArray[1], TestData[1]);
+                VerifyResult(resArray[2], TestData[2]);
+                VerifyResult(resArray[3], TestData[3]);                
+            });
         }
 
         private void VerifyResult(IChannelHeartbeat value, ChannelHeartbeatEntity expected)
@@ -210,6 +218,15 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Tests
         private static string GetTableEndPoint()
         {
             return "https://" + WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountName + ".table.core.windows.net/";
+        }
+
+        private static List<string> GetChannelIds()
+        {
+            return new List<string>
+            {
+                ChannelId.ToString(), 
+                ChannelIdentifierPrefix + ChannelId,
+            };
         }
     }
 }

--- a/test/net/Scenario/Telemetry/StreamingEndPointRequsestLogCollectionE2ETest.cs
+++ b/test/net/Scenario/Telemetry/StreamingEndPointRequsestLogCollectionE2ETest.cs
@@ -15,6 +15,7 @@
 // </license>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -92,6 +93,9 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Tests
 
         private readonly TraceListener _consoleTraceListener = new ConsoleTraceListener();
 
+        private const string StreamingEndPointIdentifierPrefix = "nb:oid:UUID:";
+
+
         [TestInitialize]
         public void SetupTest()
         {
@@ -154,36 +158,42 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Tests
 
         private void TestQuery1()
         {
-            var res = _mediaConext.StreamingEndPointRequestLogs.GetStreamingEndPointMetrics(
-                GetTableEndPoint(),
-                WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountKey,
-                AccountId.ToString(),
-                StreamingEndPointId.ToString(),
-                new DateTime(2012, 3, 2, 21, 53, 38, DateTimeKind.Utc),
-                new DateTime(2012, 3, 2, 21, 53, 40, DateTimeKind.Utc));
-            Assert.IsNotNull(res);
-            var resArray = res.ToArray();
-            Assert.AreEqual(resArray.Length, 2);
-            VerifyResult(resArray[0], TestData[0]);
-            VerifyResult(resArray[1], TestData[1]);
+            GetStreamingEndpointIds().ForEach(streamingEndpointId =>
+            {
+                var res = _mediaConext.StreamingEndPointRequestLogs.GetStreamingEndPointMetrics(
+                    GetTableEndPoint(),
+                    WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountKey,
+                    AccountId.ToString(),
+                    streamingEndpointId,
+                    new DateTime(2012, 3, 2, 21, 53, 38, DateTimeKind.Utc),
+                    new DateTime(2012, 3, 2, 21, 53, 40, DateTimeKind.Utc));
+                Assert.IsNotNull(res);
+                var resArray = res.ToArray();
+                Assert.AreEqual(resArray.Length, 2);
+                VerifyResult(resArray[0], TestData[0]);
+                VerifyResult(resArray[1], TestData[1]);                
+            });
         }
 
         private void TestQuery2()
         {
-            var res = _mediaConext.StreamingEndPointRequestLogs.GetStreamingEndPointMetrics(
-                GetTableEndPoint(),
-                WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountKey,
-                AccountId.ToString(),
-                StreamingEndPointId.ToString(),
-                new DateTime(2012, 3, 2, 21, 53, 38, DateTimeKind.Utc),
-                new DateTime(2012, 3, 3, 21, 53, 40, DateTimeKind.Utc));
-            Assert.IsNotNull(res);
-            var resArray = res.ToArray();
-            Assert.AreEqual(resArray.Length, 4);
-            VerifyResult(resArray[0], TestData[0]);
-            VerifyResult(resArray[1], TestData[1]);
-            VerifyResult(resArray[2], TestData[2]);
-            VerifyResult(resArray[3], TestData[3]);
+            GetStreamingEndpointIds().ForEach(streamingEndpointId =>
+            {
+                var res = _mediaConext.StreamingEndPointRequestLogs.GetStreamingEndPointMetrics(
+                    GetTableEndPoint(),
+                    WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountKey,
+                    AccountId.ToString(),
+                    streamingEndpointId,
+                    new DateTime(2012, 3, 2, 21, 53, 38, DateTimeKind.Utc),
+                    new DateTime(2012, 3, 3, 21, 53, 40, DateTimeKind.Utc));
+                Assert.IsNotNull(res);
+                var resArray = res.ToArray();
+                Assert.AreEqual(resArray.Length, 4);
+                VerifyResult(resArray[0], TestData[0]);
+                VerifyResult(resArray[1], TestData[1]);
+                VerifyResult(resArray[2], TestData[2]);
+                VerifyResult(resArray[3], TestData[3]);                
+            });
         }
 
         private void VerifyResult(IStreamingEndPointRequestLog value, StreamingEndPointRequestLogEntity expected)
@@ -207,5 +217,14 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Tests
         {
             return "https://" + WindowsAzureMediaServicesTestConfiguration.TelemetryStorageAccountName + ".table.core.windows.net/";
         }
+
+        private static List<string> GetStreamingEndpointIds()
+        {
+            return new List<string>
+            {
+                StreamingEndPointId.ToString(),
+                StreamingEndPointIdentifierPrefix + StreamingEndPointId
+            };
+        } 
     }
 }


### PR DESCRIPTION
Currently, the query methods for telemetry data accept the streaming endpoint id and channel id as the guid format rather than the format with the uuid prefix.

This change makes these methods accept both for customers' convenience.

Validation:
Update the current test cases to validate the change.