### PR TITLE
Bug 181

### DIFF
--- a/src/net/Client/TransientFaultHandling/QueryErrorDetectionStrategy.cs
+++ b/src/net/Client/TransientFaultHandling/QueryErrorDetectionStrategy.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace Microsoft.WindowsAzure.MediaServices.Client.TransientFaultHandling
 {
-    class QueryErrorDetectionStrategy : MediaErrorDetectionStrategy
+    public class QueryErrorDetectionStrategy : MediaErrorDetectionStrategy
     {
         protected override bool CheckIsTransient(Exception ex)
         {


### PR DESCRIPTION
This change makes QueryErrorDetectionStrategy public.  This is useful when you're overriding the retry policy, but want to reuse the standard error detection strategy.