### PR TITLE
Add Azure AD certificate authentication support for SDK.

### DIFF
--- a/src/net/Client/Common/Common.Authentication/AzureAdClientCertificate.cs
+++ b/src/net/Client/Common/Common.Authentication/AzureAdClientCertificate.cs
@@ -1,0 +1,57 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AzureAdClientCertificate.cs" company="Microsoft">Copyright 2012 Microsoft Corporation</copyright>
+// <license>
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </license>
+
+using System;
+
+namespace Microsoft.WindowsAzure.MediaServices.Client
+{
+    /// <summary>
+    /// Describes Azure AD client certificate credential.
+    /// </summary>
+    public class AzureAdClientCertificate
+    {
+        /// <summary>
+        /// Gets the client ID.
+        /// </summary>
+        public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the client certificate thumbprint.
+        /// </summary>
+        public string ClientCertificateThumbprint { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureAdClientCertificate"/> class.
+        /// </summary>
+        /// <param name="clientId">The client ID.</param>
+        /// <param name="clientCertificateThumbprint">The client certificate thumbprint.</param>
+        public AzureAdClientCertificate(string clientId, string clientCertificateThumbprint)
+        {
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentException("clientId");
+            }
+
+            if (string.IsNullOrWhiteSpace(clientCertificateThumbprint))
+            {
+                throw new ArgumentException("clientCertificateThumbprint");
+            }
+
+            ClientId = clientId;
+            ClientCertificateThumbprint = clientCertificateThumbprint;
+        }
+    }
+}

--- a/src/net/Client/Common/Common.Authentication/AzureAdClientSymmetricKey.cs
+++ b/src/net/Client/Common/Common.Authentication/AzureAdClientSymmetricKey.cs
@@ -1,0 +1,57 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AzureAdClientSymmetricKey.cs" company="Microsoft">Copyright 2012 Microsoft Corporation</copyright>
+// <license>
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </license>
+
+using System;
+
+namespace Microsoft.WindowsAzure.MediaServices.Client
+{
+    /// <summary>
+    /// Describes Azure AD client symmetric key credential.
+    /// </summary>
+    public class AzureAdClientSymmetricKey
+    {
+        /// <summary>
+        /// Gets the client ID.
+        /// </summary>
+        public string ClientId { get; }
+        
+        /// <summary>
+        /// Gets the client key.
+        /// </summary>
+        public string ClientKey { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureAdClientSymmetricKey"/> class.
+        /// </summary>
+        /// <param name="clientId">The client ID.</param>
+        /// <param name="clientKey">The client key.</param>
+        public AzureAdClientSymmetricKey(string clientId, string clientKey)
+        {
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentException("clientId");
+            }
+
+            if (string.IsNullOrWhiteSpace(clientKey))
+            {
+                throw new ArgumentException("clientKey");
+            }
+
+            ClientId = clientId;
+            ClientKey = clientKey;
+        }
+    }
+}

--- a/src/net/Client/Common/Common.Authentication/AzureAdTokenCredentialType.cs
+++ b/src/net/Client/Common/Common.Authentication/AzureAdTokenCredentialType.cs
@@ -19,7 +19,7 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
     /// <summary>
     /// Describes the AAD token crendential type.
     /// </summary>
-    public enum AzureAdTokenCredentialType
+    internal enum AzureAdTokenCredentialType
     {
         /// <summary>
         /// User Credential by prompting user for user name and password.
@@ -27,8 +27,13 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
         UserCredential,
 
         /// <summary>
-        /// Service Principal credential.
+        /// Service Principal with the symmetric key credential.
         /// </summary>
-        ServicePrincipal
+        ServicePrincipalWithClientSymmetricKey,
+
+        /// <summary>
+        /// Service Principal with the certificate credential.
+        /// </summary>
+        ServicePrincipalWithClientCertificate
     }
 }

--- a/src/net/Client/Common/Common.Authentication/AzureAdTokenProvider.cs
+++ b/src/net/Client/Common/Common.Authentication/AzureAdTokenProvider.cs
@@ -84,12 +84,11 @@ namespace Microsoft.WindowsAzure.MediaServices.Client
                         _tokenCredentials.AzureEnvironment.MediaServicesSdkRedirectUri,
                         new PlatformParameters(PromptBehavior.Auto)).Result;
 
-                case AzureAdTokenCredentialType.ServicePrincipal:
-                    return  _authenticationContext.AcquireTokenAsync(
-                        mediaServicesResource,
-                        new ClientCredential(
-                            _tokenCredentials.ClientId,
-                            _tokenCredentials.ClientSecret)).Result;
+                case AzureAdTokenCredentialType.ServicePrincipalWithClientSymmetricKey:
+                    return  _authenticationContext.AcquireTokenAsync(mediaServicesResource, _tokenCredentials.ClientKey).Result;
+
+                case AzureAdTokenCredentialType.ServicePrincipalWithClientCertificate:
+                    return _authenticationContext.AcquireTokenAsync(mediaServicesResource, _tokenCredentials.ClientCertificate).Result;
 
                 default:
                     throw new NotSupportedException(

--- a/src/net/Client/Common/Common.Authentication/SDK.Client.Common.Authentication.csproj
+++ b/src/net/Client/Common/Common.Authentication/SDK.Client.Common.Authentication.csproj
@@ -61,8 +61,10 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AzureAdClientCertificate.cs" />
+    <Compile Include="AzureAdClientSymmetricKey.cs" />
     <Compile Include="ITokenProvider.cs" />
-	<Compile Include="AzureAdTokenCredentials.cs" />
+    <Compile Include="AzureAdTokenCredentials.cs" />
     <Compile Include="AzureAdTokenCredentialType.cs" />
     <Compile Include="AzureAdTokenProvider.cs" />
     <Compile Include="AzureEnvironmentConstants.cs" />
@@ -75,6 +77,12 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common.FileEncryption\SDK.Client.Common.FileEncryption.csproj">
+      <Project>{630d064c-8d3d-4419-bcc9-a61ef577a387}</Project>
+      <Name>SDK.Client.Common.FileEncryption</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/test/net/Scenario/AadAuthentication/AadAuthenticationE2ETests.cs
+++ b/test/net/Scenario/AadAuthentication/AadAuthenticationE2ETests.cs
@@ -52,15 +52,31 @@ namespace Microsoft.WindowsAzure.MediaServices.Client.Tests.AadAuthentication
         [TestMethod]
         [TestCategory("ClientSDK")]
         [Owner("ClientSDK")]
-        public void TestServicePrincipalCredential()
+        public void TestServicePrincipalWithClientSymmetricKey()
         {
             var clientId = ConfigurationManager.AppSettings["ClientIdForAdAuth"];
             var clientSecret = ConfigurationManager.AppSettings["ClientSecretForAdAuth"];
 
             var environment = GetSelfDefinedEnvironment();
-            var tokenCredentials = new AzureAdTokenCredentials(ConfigurationManager.AppSettings["UserTenant"], clientId, clientSecret, environment);
+            var tokenCredentials = new AzureAdTokenCredentials(ConfigurationManager.AppSettings["UserTenant"], new AzureAdClientSymmetricKey(clientId, clientSecret), environment);
             var tokenProvider = new AzureAdTokenProvider(tokenCredentials);
 
+            var mediaContext = new CloudMediaContext(_mediaServicesApiServerUri, tokenProvider);
+            mediaContext.Assets.FirstOrDefault();
+        }
+
+        [TestMethod]
+        [TestCategory("ClientSDK")]
+        [Owner("ClientSDK")]
+        public void TestServicePrincipalWithClientCertificate()
+        {
+            var clientId = ConfigurationManager.AppSettings["ClientIdForAdAuth"];
+            var clientCertificateThumbprint = ConfigurationManager.AppSettings["ClientCertificateThumbprintForAdAuth"];
+
+            var environment = GetSelfDefinedEnvironment();
+            var tokenCredentials = new AzureAdTokenCredentials(ConfigurationManager.AppSettings["UserTenant"], new AzureAdClientCertificate(clientId, clientCertificateThumbprint), environment);
+
+            var tokenProvider = new AzureAdTokenProvider(tokenCredentials);
             var mediaContext = new CloudMediaContext(_mediaServicesApiServerUri, tokenProvider);
             mediaContext.Assets.FirstOrDefault();
         }

--- a/test/net/Scenario/App.config
+++ b/test/net/Scenario/App.config
@@ -81,6 +81,7 @@
     <add key="MediaServicesAccountCustomApiServerEndpoint" value="" />
     <add key="ClientIdForAdAuth" value="" />
     <add key="ClientSecretForAdAuth" value="" />
+    <add key="ClientCertificateThumbprintForAdAuth" value="" />
     <add key="UserTenant" value="" />
   </appSettings>
   <startup>


### PR DESCRIPTION
Verification:
1. Create a cert and AD application.
2. Upload the key credentials to the application manifest.
3. Acquire a token successfully.
4. Also verified the other two scenarios: acquire a token with user prompt and service principal client key.